### PR TITLE
Allowing for multiple replacements of search string

### DIFF
--- a/SafariKeywordSearchWebExtension/Resources/background.js
+++ b/SafariKeywordSearchWebExtension/Resources/background.js
@@ -55,10 +55,10 @@ function getSearch(searchParam, andThen) {
         let [first, ...rest] = searchParam.split(/\s+/)
         if (searchData[first]) {
             andThen(searchData[first]
-                .replace('%%%', rest.join('+'))
-                .replace('@@@', escape(rest.join('+')))
-                .replace(/\{\{@(.+?)@\}\}/g, (...m) => escape(rest.join(m[1])))
-                .replace(/\{\{%(.+?)%\}\}/g, (...m) => rest.join(m[1])))
+                .replaceAll('%%%', rest.join('+'))
+                .replaceAll('@@@', escape(rest.join('+')))
+                .replaceAll(/\{\{@(.+?)@\}\}/g, (...m) => escape(rest.join(m[1])))
+                .replaceAll(/\{\{%(.+?)%\}\}/g, (...m) => rest.join(m[1])))
         }
 
     })


### PR DESCRIPTION
I've got a couple work urls (atlassian's confluence mainly) that have the search query in two spots of the url..
This was a small tweak to support replacing multiple `@@@` in the url..