### PR TITLE
Allow whitespace or a forward slash with keyword

### DIFF
--- a/Shared (Extension)/Resources/background.js
+++ b/Shared (Extension)/Resources/background.js
@@ -219,7 +219,7 @@ function getSearchParam(urlString) {
 }
 
 function getSearchUrl(searchParam) {
-  let parts = searchParam.split(/\s+/)
+  let parts = searchParam.split(/\s+|\//)
   let match = searchData[parts[0]]
   let searchPhrase = parts.slice(1)
 


### PR DESCRIPTION
For my use case, I would like to make a quick search with a the forward slash to match what my org does in their chrome extension.

For example:
`a test` is the same as `a/test` now, both search amazon for "test". In chrome I would type something like `action/somewhere` so I have muscle memory here and that is the only driving force for this change (and the fact I want to use your extension on my ipad/phone/work computer and have my work quick links working)